### PR TITLE
Refuse TCP connections if they fail to connect

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -120,6 +120,7 @@ func manageTun(mtu uint32, fd int, dialer proxy.Dialer, fakeDNSServer *fakedns.S
 		ep, e := r.CreateEndpoint(&wq)
 		if e != nil {
 			fmt.Fprintln(os.Stderr, e)
+			remoteConn.Close()
 			r.Complete(true)
 			return
 		}


### PR DESCRIPTION
Prior to this commit, TCP connections that fail to connect will simply hang, necessitating the client to time out instead of immediately failing.

For example, take a non-existent host:
```shell
$ proxy-ns --socks5-address=127.0.0.1:2002 curl -vIo /dev/null --no-progress-meter --max-time 5 http://example.invalid
* Host example.invalid:80 was resolved.
* IPv6: (none)
* IPv4: 240.0.0.0
*   Trying 240.0.0.0:80...
* Connected to example.invalid (240.0.0.0) port 80
* using HTTP/1.x
> HEAD / HTTP/1.1
> Host: example.invalid
> User-Agent: curl/8.14.1
> Accept: */*
>
* Request completely sent off
failed to perform client handshake: CONNECT: host unreachable
* Operation timed out after 5002 milliseconds with 0 bytes received
* closing connection #0
curl: (28) Operation timed out after 5002 milliseconds with 0 bytes received
```

Or an proxy that is down or unreliable:
```shell
$ proxy-ns --socks5-address=127.0.0.1:1 curl -vIo /dev/null --no-progress-meter --max-time 5 http://example.com
* Host example.com:80 was resolved.
* IPv6: (none)
* IPv4: 240.0.0.0
*   Trying 240.0.0.0:80...
* Connected to example.com (240.0.0.0) port 80
* using HTTP/1.x
> HEAD / HTTP/1.1
> Host: example.com
> User-Agent: curl/8.14.1
> Accept: */*
>
* Request completely sent off
failed to connect to 127.0.0.1:1: dial tcp 127.0.0.1:1: connect: connection refused
* Operation timed out after 5002 milliseconds with 0 bytes received
* closing connection #0
curl: (28) Operation timed out after 5002 milliseconds with 0 bytes received
```

After this commit, the TCP connection is accepted _only_ after the remote SOCKS connection is successfully made. If it fails, an early RST is sent, which is interpreted as Connection refused for the client.

For example, take a non-existent host:
```shell
$ sudo ./proxy-ns --socks5-address=127.0.0.1:2002 curl -vIo /dev/null --no-progress-meter --max-time 5 http://example.invalid
* Host example.invalid:80 was resolved.
* IPv6: (none)
* IPv4: 240.0.0.0
*   Trying 240.0.0.0:80...
failed to perform client handshake: CONNECT: host unreachable
* connect to 240.0.0.0 port 80 from 10.0.0.1 port 39934 failed: Connection refused
* Failed to connect to example.invalid port 80 after 1967 ms: Could not connect to server
* closing connection #0
curl: (7) Failed to connect to example.invalid port 80 after 1967 ms: Could not connect to server
```

Or an proxy that is down or unreliable:
```shell
$ sudo ./proxy-ns --socks5-address=127.0.0.1:1 curl -vIo /dev/null --no-progress-meter --max-time 5 http://example.com
* Host example.com:80 was resolved.
* IPv6: (none)
* IPv4: 240.0.0.0
*   Trying 240.0.0.0:80...
failed to connect to 127.0.0.1:1: dial tcp 127.0.0.1:1: connect: connection refused
* connect to 240.0.0.0 port 80 from 10.0.0.1 port 52502 failed: Connection refused
* Failed to connect to example.com port 80 after 2 ms: Could not connect to server
* closing connection #0
curl: (7) Failed to connect to example.com port 80 after 2 ms: Could not connect to server
```